### PR TITLE
Adiciona "memoize" na renderização viewlet byline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,16 @@ Histórico de Alterações
 1.0.6 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-* Corrige as dependências do pacote.
-  [hvelarde]
+* Adiciona "memoize" na renderização de viewlet byline do NITF por questões de
+  performance quando há muitos usuários sendo pesquisados.
+  Ver https://github.com/collective/collective.nitf/pull/129
+  [idgserpro]
 
 * Adiciona css para title de coleção.
   [idgserpro]
+
+* Corrige as dependências do pacote.
+  [hvelarde]
 
 * Adiciona viewlets internacionalizadas (i18n) para "Voltar para o topo",
   "Desenvolvido com o CMS de código aberto Plone" e os links de acessibilidade

--- a/src/brasil/gov/portal/browser/viewlets/nitf_byline.py
+++ b/src/brasil/gov/portal/browser/viewlets/nitf_byline.py
@@ -2,12 +2,15 @@
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone import api
 from plone.app.layout.viewlets.content import DocumentBylineViewlet
+from plone.memoize import ram
+from time import time
 
 
 class NITFBylineViewlet(DocumentBylineViewlet):
 
     index = ViewPageTemplateFile('templates/nitf_byline.pt')
 
+    @ram.cache(lambda method, self, member_info: (time() // 60, member_info))
     def getMemberInfoByName(self, fullname):
         mt = api.portal.get_tool('portal_membership')
         members = mt.searchForMembers(name=fullname)

--- a/src/brasil/gov/portal/browser/viewlets/nitf_byline.py
+++ b/src/brasil/gov/portal/browser/viewlets/nitf_byline.py
@@ -10,7 +10,7 @@ class NITFBylineViewlet(DocumentBylineViewlet):
 
     index = ViewPageTemplateFile('templates/nitf_byline.pt')
 
-    @ram.cache(lambda method, self, member_info: (time() // 60, member_info))
+    @ram.cache(lambda method, self, fullname: (time() // 60, fullname))
     def getMemberInfoByName(self, fullname):
         mt = api.portal.get_tool('portal_membership')
         members = mt.searchForMembers(name=fullname)


### PR DESCRIPTION
Por questões de performance quando há muitos usuários sendo pesquisados
na viewlet byline do NITF, foi adicionado um memoize.
Ver https://github.com/collective/collective.nitf/pull/129 em
collective.nitf onde essa funcionalidade foi inicialmente implementada.