### PR TITLE
Torna pacote compatível com Products.Doormat>0.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Histórico de Alterações
 1.0.6 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+* Corrige erro do rodapé que exibia link e sessões não publicadas. Para isso,
+  forçamos Products.Doormat > 0.7 (closes `#182`_).
+  [idgserpro]
+
 * Reduzindo tamanho das imagens pelo tinypng. Taxa de redução foi de 59% do total.
   [caduvieira]
 
@@ -351,3 +355,4 @@ Histórico de Alterações
 .. _`#161`: https://github.com/plonegovbr/brasil.gov.portal/issues/161
 .. _`#173`: https://github.com/plonegovbr/brasil.gov.portal/issues/173
 .. _`#175`: https://github.com/plonegovbr/brasil.gov.portal/issues/175
+.. _`#182`: https://github.com/plonegovbr/brasil.gov.portal/issues/182

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'Products.CMFCore',
         'Products.CMFDefault',
         'Products.CMFPlone',
-        'Products.Doormat<0.8',
+        'Products.Doormat>0.7',
         'Products.GenericSetup',
         'Products.PloneFormGen',
         'sc.contentrules.groupbydate',

--- a/src/brasil/gov/portal/browser/content/doormat.py
+++ b/src/brasil/gov/portal/browser/content/doormat.py
@@ -35,7 +35,7 @@ class DoormatView(BaseView):
                 for link in section['section_links']:
                     link_url = link['link_url']
                     url = link_url
-                    if not isinstance(link_url, str):
+                    if not isinstance(link_url, unicode):
                         link_url = link_url()
                     if '${navigation_root_url}' in link_url:
                         url = link_url.replace(

--- a/src/brasil/gov/portal/setuphandlers.py
+++ b/src/brasil/gov/portal/setuphandlers.py
@@ -52,6 +52,9 @@ def setupPortalContent(p):
                'videos', 'audios', 'links', 'pastas-com-exemplos-de-pecas']
     publish_content(p, obj_ids)
 
+    # Remove conteúdo default do Doormat
+    remove_conteudo_doormat(p)
+
 
 def capa_como_padrao(portal):
     if not hasattr(portal, 'default_page'):
@@ -124,7 +127,7 @@ def configura_ultimas_noticias(portal):
         colecao = portal[oId]
     colecao.sort_on = u'effective'
     colecao.reverse_sort = True
-    #: Query by Type and Review State
+    # : Query by Type and Review State
     colecao.query = [
         {'i': u'portal_type',
          'o': u'plone.app.querystring.operation.selection.is',
@@ -202,6 +205,14 @@ def set_tinymce_formats(context):
 
         json_formats = safe_unicode(json.dumps(dict_formats), 'utf-8')
         getUtility(ITinyMCE).formats = json_formats
+
+
+def remove_conteudo_doormat(context):
+    """Remove conteúdo default do Products.Doormat"""
+    # presente em Products.Doormat > 0.8
+    doormat = getattr(context, 'doormat', None)
+    if doormat:
+        api.content.delete(doormat)
 
 
 def importContent(context):

--- a/src/brasil/gov/portal/setuphandlers.py
+++ b/src/brasil/gov/portal/setuphandlers.py
@@ -189,7 +189,7 @@ def instala_dependencias(context):
         _instala_pacote(qi, p)
 
 
-def set_tinymce_formats(context):
+def set_tinymce_formats():
     # Baseado em: https://dev.plone.org/ticket/13715
     if getUtility(ITinyMCE).formats is None:
         # Como ainda não existem estilos, posso adicionar diretamente.
@@ -222,4 +222,4 @@ def importContent(context):
         return
     site = api.portal.get()
     setupPortalContent(site)
-    set_tinymce_formats(context)
+    set_tinymce_formats()

--- a/src/brasil/gov/portal/upgrades/v10600/handler.py
+++ b/src/brasil/gov/portal/upgrades/v10600/handler.py
@@ -20,7 +20,7 @@ def install_product(context):
 
 
 def set_some_tiny_formats(context):
-    set_tinymce_formats(context)
+    set_tinymce_formats()
 
     # Novas regras foram adicionadas nos arquivos css.
     api.portal.get_tool('portal_css').cookResources()


### PR DESCRIPTION
Torna pacote compatível com Products.Doormat>0.7, de forma a corrigir problema em que conteúdos não publicados apareciam no rodapé. Para evitar o problema, forço Products.Doormat>0.7. Foi atualizado a versão do Products.Doormat em https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg#L13. @hvelarde favor revisar e fazer o merge o mais rápido possível, porque a atualização do Products.Doormat irá quebrar as outras branchs. Assim, após o merge, as outras branchs terão que fazer rebase.