### PR TITLE
Atualiza Products.TinyMCE para 1.4.3

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -46,3 +46,4 @@ eggs = ${test:eggs}
 brasil.gov.portal =
 # use latest version of setuptools
 setuptools =
+Products.TinyMCE = 1.4.3


### PR DESCRIPTION
Testei o Products.TinyMCE 1.4.3 como sugerido pelo @rodfersou em https://github.com/plonegovbr/brasil.gov.portal/issues/208#issuecomment-127982489 e não tive problemas. Não há upgrade step a ser executado na atualização.

Não é necessário dar merge nesse PR. Ele é só para comprovar que os testes funcionam com a versão 1.4.3:

https://travis-ci.org/plonegovbr/brasil.gov.portal/builds/83911288

@hvelarde você pode atualizar a versão no arquivo: https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg. Não temos permissão nesse repositório.
