### PR TITLE
Pina versão do plone.app.querystring para 1.2.9

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -62,3 +62,4 @@ compile-mo-files = true
 brasil.gov.portal =
 # use latest version of setuptools
 setuptools =
+plone.app.querystring = 1.2.9


### PR DESCRIPTION
Não deve ser feito merge desse PR. Essa pinagem é feita somente para confirmar se os testes passam com essa versão. A pinagem deve ser feita em:

https://github.com/plonegovbr/portal.buildout/blob/master/buildout.d/versions.cfg

A versão 1.2.9 closes #191.

