### PR TITLE
Testa toda a data ao invés de testar somente parte

### DIFF
--- a/src/brasil/gov/portal/tests/test_esconde_autor_data.py
+++ b/src/brasil/gov/portal/tests/test_esconde_autor_data.py
@@ -86,13 +86,10 @@ class EscondeAutorDataFunctionalTestCase(unittest.TestCase):
     def base_teste_data(self, obj, contents):
         """Testa que a data de publicação e a data de modificação não aparecem
          na página."""
-        datas = (obj.EffectiveDate(), obj.ModificationDate())
+        datas = (obj.effective(), obj.modified())
         for data in datas:
             self.assertNotEqual('None', data)
-            ano = data[:4]
-            dia = data[8:10]
-            self.assertNotIn('/{0}'.format(ano), contents)
-            self.assertNotIn('{0}/'.format(dia), contents)
+            self.assertNotIn(data.strftime('%d/%m/%Y'), contents)
         self.assertNotIn('última', contents)
         self.assertNotIn('Modificado', contents)
 


### PR DESCRIPTION
Nos testes test_esconde_autor_data, estava sendo testado se o dia 'dd/'
não aparecia na tela quando a configuração para esconder a data estava
setada. Assim, quando os testes rodavam no dia 01, o que era comparado
eram '01/'. No teste da tela de busca, esse '01/' batia com a data do
combo 'Último mês', por exemplo '2016/01/30', fazendo o teste falhar.

Fix #272