### PR TITLE
Corrigi testes após release 1.1.4

### DIFF
--- a/src/brasil/gov/portal/tests/robot/test_capa.robot
+++ b/src/brasil/gov/portal/tests/robot/test_capa.robot
@@ -17,7 +17,7 @@ ${document_selector}  .ui-draggable .contenttype-document
 *** Test Cases ***
 
 Criar nova capa
-    
+
     # Todos os keywords de collective.cover têm como premissa as strings em
     # inglês na interface.
     # Como os testes de brasil.gov.portal são em português, existiam duas
@@ -30,14 +30,14 @@ Criar nova capa
     Enable Autologin as  Site Administrator
     Ir para  ${PLONE_URL}/@@language-controlpanel
     Select From List  xpath=//select[@id='form.default_language']  en
-    Clicar botao  Salvar 
+    Clicar botao  Salvar
 
     # Cria a capa Layout vazio
     Go to Homepage
     Create Cover  NewCoverLayoutVazio  NewCoverLayoutVazioDescription  Layout vazio
 
     # Adiciona um tile de banner
-    Edit Cover Layout
+    Open Layout Tab
     Add Tile  ${banner_tile_location}
     Save Cover Layout
 
@@ -54,7 +54,7 @@ Criar nova capa
     Click Link  link=View
     # Na estrutura atual, provavelmente vai pegar o item "Acessibilidade"
     # Se novos tipos padrão de conteúdo inicial forem adicionados
-    # em brasil.gov.portal, esse xpath pode ter que mudar para referenciar  
+    # em brasil.gov.portal, esse xpath pode ter que mudar para referenciar
     # outro documento.
     Wait Until Page Contains Element  xpath=//div[contains(@class, 'cover-banner-tile tile-content')]/h2/a[contains(@href, "acessibilidade")]
 
@@ -75,6 +75,6 @@ Criar nova capa
     Click Link  link=View
     # Na estrutura atual, provavelmente vai pegar o item "Acessibilidade"
     # Se novos tipos padrão de conteúdo inicial forem adicionados
-    # em brasil.gov.portal, esse xpath pode ter que mudar para referenciar  
+    # em brasil.gov.portal, esse xpath pode ter que mudar para referenciar
     # outro documento.
     Wait Until Page Contains Element  xpath=//div[@id='em-destaque']/ul[contains(@class, 'sortable-tile cover-list-tile')]/li/a[contains(@href, "acessibilidade")]

--- a/src/brasil/gov/portal/tests/test_setup.py
+++ b/src/brasil/gov/portal/tests/test_setup.py
@@ -391,10 +391,7 @@ class TestUpgrade(unittest.TestCase):
             self.assertFalse(isinstance(pasta.getOrdering(), DefaultOrdering))
 
         self.st.setLastVersionForProfile('brasil.gov.tiles:default', '2000')
-        self.assertEqual(
-            len(self.st.listUpgrades('brasil.gov.tiles:default')),
-            1
-        )
+        self.assertTrue(len(self.st.listUpgrades('brasil.gov.tiles:default')))
 
         self.execute_upgrade(u'10600', u'10700')
 


### PR DESCRIPTION
- Após o release 1.1rc1 do brasil.gov.tiles ele passou a ter mais de um
upgrade step após o upgrade 2000.

- Após o release 1.1b1 do collective.cover a keyword 'Edit Cover Layout'
passou a se chamar 'Open Layout Tab'.

Fixes #291