### PR TITLE
Adiciona diretiva do plone4.csrffixes no dependencies.zcml para que seja carregado este produto quando os testes são executados

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Histórico de Alterações
 1.1.5 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+* Adiciona diretiva do plone4.csrffixes no dependencies.zcml (closes `#279`_).
+  [idgserpro]
+
 * Corrige o "Link to Collection" impedindo que o rodapé desse erro com links
   para coleções. (closes `#95`_).
   [idgserpro]
@@ -467,3 +470,4 @@ Histórico de Alterações
 .. _`#241`: https://github.com/plonegovbr/brasil.gov.portal/issues/241
 .. _`#242`: https://github.com/plonegovbr/brasil.gov.portal/issues/242
 .. _`#275`: https://github.com/plonegovbr/brasil.gov.portal/issues/275
+.. _`#279`: https://github.com/plonegovbr/brasil.gov.portal/issues/279

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -18,18 +18,6 @@ parts +=
     rebuild_i18n-sh
     precompile
 
-[test]
-environment = testenv
-
-[testenv]
-PLONE_CSRF_DISABLED = true
-
-[test]
-environment = testenv
-
-[testenv]
-PLONE_CSRF_DISABLED = true
-
 [code-analysis]
 recipe = plone.recipe.codeanalysis
 directory = ${buildout:directory}/src/brasil/gov/portal

--- a/src/brasil/gov/portal/dependencies.zcml
+++ b/src/brasil/gov/portal/dependencies.zcml
@@ -13,6 +13,7 @@
   <include package="collective.polls" />
   <include package="collective.upload" />
   <include package="plone.app.contenttypes" />
+  <include package="plone4.csrffixes" />
   <include package="Products.CMFPlone" />
   <include package="Products.Doormat" />
   <include package="Products.PloneFormGen" />

--- a/src/brasil/gov/portal/tests/robot/test_capa.robot
+++ b/src/brasil/gov/portal/tests/robot/test_capa.robot
@@ -14,6 +14,24 @@ ${banner_tile_location}  'collective.cover.banner'
 ${tile_selector}  div.tile-container div.tile
 ${document_selector}  .ui-draggable .contenttype-document
 
+*** Keywords ***
+# Metodo retirado do teste cover.robot do collective.cover para sobrescrever a chamada
+# deste metodo aqui no test_capa.robot, esta customização é necessária pois temos que inserir
+# Input Text For Sure para que o teste execute sem erros no travis
+# FIXME: essa customização já foi realizada no produto collective.cover:
+# https://github.com/collective/collective.cover/commit/dfd128a1ca6a75edc5f5190919bcffe7c9b4182f
+# A customização pode ser removida quando utilizarmos o collective.cover versão > 1.2b1
+Create Cover
+    [arguments]  ${title}  ${description}  ${layout}=Empty layout
+
+    Click Add Cover
+    # deal with delays caused by plone4.csrffixes
+    Input Text For Sure  css=${title_selector}  ${title}
+    Input Text  css=${description_selector}  ${description}
+    Select From List  css=${layout_selector}  ${layout}
+    Click Button  Save
+    Page Should Contain  Item created
+
 *** Test Cases ***
 
 Criar nova capa


### PR DESCRIPTION
Adiciona diretiva do plone4.csrffixes no dependencies.zcml para que seja carregado este produto quando os testes são executados.

fixes #279 