### PR TITLE
Corrige "Link to Collection".

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Histórico de Alterações
 1.1.5 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+* Corrige o "Link to Collection" impedindo que o rodapé desse erro com links
+  para coleções. (closes `#95`_).
+  [idgserpro]
+
 * Complementa a css das tiles (closes `#189`_).
   [idgserpro]
 
@@ -421,6 +425,7 @@ Histórico de Alterações
 .. _`#88`: https://github.com/plonegovbr/brasil.gov.portal/issues/88
 .. _`#90`: https://github.com/plonegovbr/brasil.gov.portal/issues/90
 .. _`#93`: https://github.com/plonegovbr/brasil.gov.portal/issues/93
+.. _`#95`: https://github.com/plonegovbr/brasil.gov.portal/issues/95
 .. _`#96`: https://github.com/plonegovbr/brasil.gov.portal/issues/96
 .. _`#98`: https://github.com/plonegovbr/brasil.gov.portal/issues/98
 .. _`#100`: https://github.com/plonegovbr/brasil.gov.portal/issues/100

--- a/src/brasil/gov/portal/browser/content/configure.zcml
+++ b/src/brasil/gov/portal/browser/content/configure.zcml
@@ -14,6 +14,9 @@
         />
   </browser:menuItems>
 
+  <!--FIXME:-->
+  <!--BBB:-->
+  <!--Veja em doormat.py quando esse override poderá ser removido.-->
   <!-- Overrides do Doormat-->
   <browser:page
       for="Products.Doormat.content.interfaces.IDoormat"

--- a/src/brasil/gov/portal/browser/content/doormat.py
+++ b/src/brasil/gov/portal/browser/content/doormat.py
@@ -2,6 +2,13 @@
 from Products.Doormat.browser.views import DoormatView as BaseView
 
 
+# FIXME
+# BBB
+# Essa customização, a partir do Products.Doormat 1.2, poderá ser
+# completamente removida. Para maiores detalhes, veja
+# https://github.com/plonegovbr/brasil.gov.portal/issues/95#issuecomment-229473089
+# Ver se não existe algum teste associado a essa customização para que também
+# seja removido.
 class DoormatView(BaseView):
     """ Doormat View lidando com os dados de links
     """
@@ -35,8 +42,6 @@ class DoormatView(BaseView):
                 for link in section['section_links']:
                     link_url = link['link_url']
                     url = link_url
-                    if not isinstance(link_url, unicode):
-                        link_url = link_url()
                     if '${navigation_root_url}' in link_url:
                         url = link_url.replace(
                             '${navigation_root_url}',

--- a/src/brasil/gov/portal/tests/test_init_content.py
+++ b/src/brasil/gov/portal/tests/test_init_content.py
@@ -195,6 +195,36 @@ class InitContentTestCase(unittest.TestCase):
         # Products.Doormat > 0.7
         self.assertNotIn(obj_sessao.Title(), titulos_sessoes)
 
+    def test_conteudo_link_colecao_doormat(self):
+        """Testa se funciona adicionar um link para uma coleção no rodapé."""
+        # FIXME:
+        # BBB:
+        # Quando o Products.Doormat for atualizado para 1.2, esse teste pode ser
+        # removido uma vez que ele será feito pelo próprio Doormat, em
+        # https://github.com/collective/Products.Doormat/blob/94c0e161b179c4820548a24a0804c5e65c747be5/Products/Doormat/tests/test_views.py#L49
+        # e só faz sentido porque hoje ele é customizado em brasil.gov.portal,
+        # mas a customização pode ser removida quando for atualizar essa versão.
+        # Ver
+        # https://github.com/plonegovbr/brasil.gov.portal/issues/95#issuecomment-229473089
+        ultimas_noticias_doormat = api.content.create(
+            type='DoormatCollection',
+            container=self.portal['rodape']['quarta_coluna']['navegacao'],
+            id='ultimas-noticias'
+        )
+        ultimas_noticias_doormat.setCollection(self.portal['ultimas-noticias'])
+        view = self.get_doormat_view()
+        data = view.getDoormatData()
+
+        total_collection_items = 11
+
+        total_collection_found = len([
+            link
+            for link in data[3]['column_sections'][1]['section_links']
+            if link['link_class'] == 'collection-item'
+        ])
+
+        self.assertEqual(total_collection_items, total_collection_found)
+
     def test_conteudo_doormat_removido(self):
         """Testa se o conteúdo default do Products.Doormat foi removido"""
         self.assertNotIn('doormat', self.portal.objectIds())


### PR DESCRIPTION
Corrige o "Link to Collection" impedindo que o rodapé desse erro com links
para coleções.

Fecha relato https://github.com/plonegovbr/brasil.gov.portal/issues/95