### PR TITLE
Remove -Nq do buildout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 install:
 - python bootstrap.py
 - bin/buildout annotate
-- bin/buildout -Nq
+- bin/buildout
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Evita o uso de cache, uma vez que ao utilizar esse recurso "mascaramos" erros que deveriam ser apresentados durante a integração contínua.