### PR TITLE
Corrige upgradeStep 10700 (#289).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Histórico de Alterações
   [finnicius]
 
 * Adiciona diretiva do plone4.csrffixes no dependencies.zcml (closes `#279`_).
+
+* Corrige upgradeStep 10700 para que execute o método "simplify_layout" do
+  collective.cover, necessário para se evitar quebra de capa dependendo da
+  ordem em que os upgradeSteps são executados. (closes `#289`_)
   [idgserpro]
 
 * Corrige o "Link to Collection" impedindo que o rodapé desse erro com links
@@ -475,4 +479,5 @@ Histórico de Alterações
 .. _`#242`: https://github.com/plonegovbr/brasil.gov.portal/issues/242
 .. _`#275`: https://github.com/plonegovbr/brasil.gov.portal/issues/275
 .. _`#279`: https://github.com/plonegovbr/brasil.gov.portal/issues/279
+.. _`#289`: https://github.com/plonegovbr/brasil.gov.portal/issues/289
 .. _`#303`: https://github.com/plonegovbr/brasil.gov.portal/issues/303

--- a/src/brasil/gov/portal/upgrades/v10700/handler.py
+++ b/src/brasil/gov/portal/upgrades/v10700/handler.py
@@ -4,6 +4,7 @@ from brasil.gov.portal.logger import logger
 from brasil.gov.portal.upgrades import upgrade_profile
 from collective.cover.controlpanel import ICoverSettings
 from collective.cover.interfaces import ICover
+from collective.cover.upgrades.v11 import simplify_layout
 from plone import api
 from plone.app.contenttypes.interfaces import IFolder
 from plone.app.upgrade.utils import loadMigrationProfile
@@ -159,6 +160,13 @@ def corrige_conteudo_collectivecover(portal_setup):
         obj.cover_layout = _corrige_conteudo_collectivecover(obj,
                                                              obj.cover_layout)
         logger.info('"{0}" was updated'.format(obj.absolute_url_path()))
+
+    # Necessário caso os upgradeSteps não sejam executados na ordem correta.
+    # Ver https://github.com/plonegovbr/brasil.gov.portal/issues/289
+    # Esse método está presente no collective.cover a partir da versão 1.0a11,
+    # e essa versão é pinada no IDG 1.1.3, momento em que esse upgradeStep foi
+    # gerado.
+    simplify_layout(api.portal.get())
 
 
 def apply_profile(portal_setup):


### PR DESCRIPTION
Corrige upgradeStep 10700 para que execute o método "simplify_layout" do
collective.cover, necessário para se evitar quebra de capa dependendo da
ordem em que os upgradeSteps são executados.

closes https://github.com/plonegovbr/brasil.gov.portal/issues/289