### PR TITLE
[nitf_byline] Deixa de buscar dados do usuário quando o autor é indefinido 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Histórico de Alterações
   collective.oembed e plone.app.collection.
   [idgserpro]
 
+* Na viewlet NITFBylineViewlet, deixamos de buscar dados do usuário quando o
+  autor é indefinido (closes `#320`).
+  [tcurvelo]
+
 * Corrige a exibição de notícias com portlets, além de outras páginas onde seja
   usado o CSS selector div.width-1:2. (closes `#303`_).
   [finnicius]

--- a/src/brasil/gov/portal/browser/viewlets/nitf_byline.py
+++ b/src/brasil/gov/portal/browser/viewlets/nitf_byline.py
@@ -20,9 +20,11 @@ class NITFBylineViewlet(DocumentBylineViewlet):
             return mt.getMemberInfo(member)
 
     def byline(self):
-        member = self.getMemberInfoByName(self.context.byline)
-        if member:
-            return member['username']
+        fullname = self.context.byline
+        if fullname:
+            member = self.getMemberInfoByName(fullname)
+            if member:
+                return member['username']
 
     def author(self):
         return self.getMemberInfoByName(self.context.byline)

--- a/src/brasil/gov/portal/tests/test_viewlets.py
+++ b/src/brasil/gov/portal/tests/test_viewlets.py
@@ -338,6 +338,18 @@ class NITFBylineViewletTestCase(unittest.TestCase):
         viewlet = self.viewlet()
         self.assertFalse(viewlet.byline())
 
+    def test_autor_indefinido(self):
+        viewlet = self.viewlet()
+        viewlet.getMemberInfoByName = lambda x: {'username': 'mock_user'}
+
+        # Assegura que 'getMemberInfoByname' é chamada para um autor qualquer
+        self.conteudo.byline = u'Usuário Qualquer'
+        self.assertEqual(viewlet.byline(), 'mock_user')
+
+        # Assegura que 'getMemberInfoByname' NÃO é chamada sem um autor
+        self.conteudo.byline = u''
+        self.assertIsNone(viewlet.byline())
+
     def test_byline(self):
         viewlet = self.viewlet()
         self.assertEqual(viewlet.byline(), 'machado')


### PR DESCRIPTION
(Desculpem ter fechado o outro PR, por um lapso o nome do branch referenciava uma issue arbitrária)

Pessoal, eu percebi que o viewlet `byline` estava fazendo algo que me parece não fazer sentido: 
quando o autor não é definido, a viewlet faz uma busca que retorna todos os membros do site (!) e retorna o primeiro (!!). 

```
members = mt.searchForMembers(name='')  
# (...)
return members[0]
```

No nosso caso, que usamos LDAP e temos 1500+ usuários, essa busca é custosa. Por causa dela, sempre que alguém acessava uma notícia que não tinha autor definido, levavam vários segundos para carregar a página.

Apesar da solução de cache que o @idgserpro apontou (#194), essa não parece solução para esse problema: o registro em cache não é do usuário correto (visto que não há um definido), e a curta duração do cache só vai adiar a consulta custosa e desnecessária por apenas 1 minuto.