### PR TITLE
Corrige erro de regressão do #157 (data 1969)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Histórico de Alterações
 1.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Corrige erro de regressão na exibição da data na visão sumária. Com a
+  atualização do plone.app.contenttypes, a lógica da template precisa chamar
+  um método e não um atributo indexado de um brain. (relacionado a `#157`_).
+  [idgserpro]
 
 
 1.2 (2017-09-22)

--- a/src/brasil/gov/portal/browser/plone/templates/listing_summary.pt
+++ b/src/brasil/gov/portal/browser/plone/templates/listing_summary.pt
@@ -157,7 +157,7 @@
                     </span>
                 </tal:name>
                 <tal:modified condition="python: item_type != 'Event' and mostra_data"
-                              define="itemDate python:item.EffectiveDate() == 'None' and item.modified or item.effective">
+                              define="itemDate python: item.modified if item.EffectiveDate() == 'None' else item.effective">
                     <span class="hiddenStructure">
                         <tal:mod i18n:translate="box_published">
                             Published

--- a/src/brasil/gov/portal/browser/plone/templates/listing_summary.pt
+++ b/src/brasil/gov/portal/browser/plone/templates/listing_summary.pt
@@ -157,7 +157,7 @@
                     </span>
                 </tal:name>
                 <tal:modified condition="python: item_type != 'Event' and mostra_data"
-                              define="itemDate python:item.EffectiveDate == 'None' and item.modified or item.effective">
+                              define="itemDate python:item.EffectiveDate() == 'None' and item.modified or item.effective">
                     <span class="hiddenStructure">
                         <tal:mod i18n:translate="box_published">
                             Published

--- a/src/brasil/gov/portal/config.py
+++ b/src/brasil/gov/portal/config.py
@@ -5,6 +5,12 @@ from zope.interface import implements
 
 PROJECTNAME = 'brasil.gov.portal'
 
+LOCAL_TIME_FORMAT = '%d/%m/%Y'
+
+TIME_FORMAT = '%Hh%M'
+
+LOCAL_LONG_TIME_FORMAT = '{0} {1}'.format(LOCAL_TIME_FORMAT, TIME_FORMAT)
+
 REDES = [
     {'id': 'facebook',
      'title': 'Facebook',

--- a/src/brasil/gov/portal/tests/test_esconde_autor_data.py
+++ b/src/brasil/gov/portal/tests/test_esconde_autor_data.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Testes da funcionalidade de esconder autor e data."""
 
+from brasil.gov.portal.config import LOCAL_TIME_FORMAT
 from brasil.gov.portal.tests.test_viewlets import esconde_autor
 from brasil.gov.portal.tests.test_viewlets import esconde_data
 from brasil.gov.portal.testing import FUNCTIONAL_TESTING
@@ -89,7 +90,7 @@ class EscondeAutorDataFunctionalTestCase(unittest.TestCase):
         datas = (obj.effective(), obj.modified())
         for data in datas:
             self.assertNotEqual('None', data)
-            self.assertNotIn(data.strftime('%d/%m/%Y'), contents)
+            self.assertNotIn(data.strftime(LOCAL_TIME_FORMAT), contents)
         self.assertNotIn('última', contents)
         self.assertNotIn('Modificado', contents)
 

--- a/src/brasil/gov/portal/tests/test_portal_properties.py
+++ b/src/brasil/gov/portal/tests/test_portal_properties.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from brasil.gov.portal.config import LOCAL_TIME_FORMAT
+from brasil.gov.portal.config import LOCAL_LONG_TIME_FORMAT
 from brasil.gov.portal.testing import INTEGRATION_TESTING
 
 import unittest
@@ -19,10 +21,13 @@ class PortalPropertiesTestCase(unittest.TestCase):
         self.types = self.portal['portal_types']
 
     def test_localTimeFormat(self):
-        self.assertEqual(self.properties.localTimeFormat, '%d/%m/%Y')
+        self.assertEqual(self.properties.localTimeFormat, LOCAL_TIME_FORMAT)
 
     def test_localLongTimeFormat(self):
-        self.assertEqual(self.properties.localLongTimeFormat, '%d/%m/%Y %Hh%M')
+        self.assertEqual(
+            self.properties.localLongTimeFormat,
+            LOCAL_LONG_TIME_FORMAT
+        )
 
     def test_enable_link_integrity_checks_enabled(self):
         self.assertTrue(self.properties.enable_link_integrity_checks)

--- a/src/brasil/gov/portal/tests/test_site_settings.py
+++ b/src/brasil/gov/portal/tests/test_site_settings.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from brasil.gov.portal.config import LOCAL_TIME_FORMAT
 from brasil.gov.portal.testing import INTEGRATION_TESTING
 
 import unittest
@@ -25,7 +26,7 @@ class SiteSettingsTestCase(unittest.TestCase):
 
     def test_localTimeFormat(self):
         site_properties = self.portal['portal_properties'].site_properties
-        self.assertEqual(site_properties.localTimeFormat, '%d/%m/%Y',
+        self.assertEqual(site_properties.localTimeFormat, LOCAL_TIME_FORMAT,
                          'Time format not set')
 
     def test_allowed_combined_language_code(self):

--- a/src/brasil/gov/portal/tests/test_views.py
+++ b/src/brasil/gov/portal/tests/test_views.py
@@ -496,7 +496,7 @@ class SummaryViewTestCase(BaseViewTestCase):
             # Curioso que na template preciso fazer
             # obj.EffectiveDate() mas não preciso obj.modified() e obj.effective()
             # (só obj.modified já volta o valor) mas aqui no Python preciso disso.
-            item_date = obj.EffectiveDate() == 'None' and obj.modified() or obj.effective()
+            item_date = obj.modified() if obj.EffectiveDate() == 'None' else obj.effective()
             # XXX: Deveria usar o toLocalizedTime, que também é usado na template
             # em listing_summary, mas não descobri, como, no código python sem
             # renderizar na template, vir traduzido. Portanto, comparo os formatos


### PR DESCRIPTION
Corrige erro de regressão na exibição da data na visão sumária. Com a
atualização do plone.app.contenttypes, a lógica da template precisa chamar
um método e não um atributo indexado de um brain.

Ou seja: item.EffectiveDate, com plone.app.contenttypes 1.0 na template era:

    <Products.ZCatalog.Catalog.mybrains object at 0x7f5cbf8f7188>

E em plone.app.contenttypes 1.1.1:

    <bound method CatalogContentListingObject.EffectiveDate of <plone.app.contentlisting.catalog.CatalogContentListingObject instance at /Plone/noticias/noticia>

Foi adicionado um teste para evitar esse problema de ocorrer novamente
no futuro e a criação de constantes padrão para padrões de datas que são
usadas nesse teste.

Esse é um bom exemplo da importância da adição de testes unitários para commits 
relativos a mudança de funcionalidade, por menor que seja.

Boas práticas para o PR: Checklist
==================================

### Foi aberta uma issue relativa a esse PR;

<!-- Marque essas opções trocando [ ] por [x] -->

- [ ] Sim
- [ ] Não
- [X] Não se aplica

### Foram adicionados testes unitários;

<!-- Marque essas opções trocando [ ] por [x] -->

- [X] Sim
- [ ] Não
- [ ] Não se aplica

### Foram adicionados testes robots;

<!-- Marque essas opções trocando [ ] por [x] -->

- [ ] Sim
- [ ] Não
- [X] Não se aplica

### Foram adicionados upgradeSteps;

<!-- Marque essas opções trocando [ ] por [x] -->

- [ ] Sim
- [ ] Não
- [X] Não se aplica

### Foi adicionada a modificação no CHANGES.rst do pacote, sempre no topo do arquivo (ou seja, na primeira linha do release ainda não lançado), contendo o seu nome de usuário do github e a referência ao issue que você está tratando (não esqueça de colocar no fim do arquivo a url para a issue, use o padrão do próprio arquivo);

<!-- Marque essas opções trocando [ ] por [x] -->

- [X] Sim
- [ ] Não
- [ ] Não se aplica

### PR não contém assuntos diferentes. PR's devem ter um objetivo claro para facilitar o review. Ex: não junte, num mesmo PR, alterações de code-analysis e de implementação. Faça um PR de code-analysis e depois o da implementação em si;

<!-- Marque essas opções trocando [ ] por [x] -->

- [X] Sim
- [ ] Não
- [ ] Não se aplica

### Evite muitos commits pequenos de um mesmo assunto no PR, sempre que possível efetue rebase;

<!-- Marque essas opções trocando [ ] por [x] -->

- [X] Sim
- [ ] Não
- [ ] Não se aplica
