### PR TITLE
Fix default configuration for collective.upload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Histórico de Alterações
 1.4rc2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Corrige configuração padrão do collective.upload (fecha #392 <https://github.com/plonegovbr/brasil.gov.portal/issues/392>`_).
+  [hvelarde]
 
 
 1.4rc1 (2017-11-01)

--- a/src/brasil/gov/portal/profiles/default/registry.xml
+++ b/src/brasil/gov/portal/profiles/default/registry.xml
@@ -129,7 +129,7 @@
     <value>1024</value>
   </record>
   <record name="collective.upload.interfaces.IUploadSettings.upload_extensions">
-    <value>gif, jpeg, jpg, png, pdf, doc, txt, docx</value>
+    <value>gif|jpeg|jpg|png|pdf|doc|txt|docx</value>
   </record>
   <records interface="plone.app.querystring.interfaces.IQueryField"
            prefix="plone.app.querystring.field.skos">

--- a/src/brasil/gov/portal/testing.py
+++ b/src/brasil/gov/portal/testing.py
@@ -7,6 +7,10 @@ from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 
+import os
+import shutil
+import tempfile
+
 
 # FIXME: workaround for https://github.com/plone/plone.app.testing/issues/39
 autoform = ('plone.autoform', {'loadZCML': True})
@@ -19,6 +23,14 @@ PLONE_FIXTURE.products = tuple(products)
 class Fixture(PloneSandboxLayer):
 
     defaultBases = (PLONE_FIXTURE,)
+
+    def setUp(self):
+        """Copy all files used in tests to the temporary directory."""
+        super(Fixture, self).setUp()
+        tempdir = tempfile.gettempdir()
+        path = os.path.join(os.path.dirname(__file__), 'tests', 'files')
+        for i in os.listdir(path):
+            shutil.copy(os.path.join(path, i), tempdir)
 
     def setUpZope(self, app, configurationContext):
         # Instala produtos

--- a/src/brasil/gov/portal/tests/robot/test_upload.robot
+++ b/src/brasil/gov/portal/tests/robot/test_upload.robot
@@ -1,0 +1,70 @@
+*** Settings ***
+
+Resource  plone/app/robotframework/keywords.robot
+Variables  plone/app/testing/interfaces.py
+Library  Remote  ${PLONE_URL}/RobotRemote
+
+Test Setup  Open test browser
+Test Teardown  Close all browsers
+
+*** Variables ***
+
+@{upload_overlay_selector}  css=form.fileupload
+@{valid_types} =  image.jpg
+@{invalid_types} =  file.mp3  file.ogg
+
+*** Test cases ***
+
+Test Upload Valid Types
+    [Documentation]  Uploading image files is allowed by default
+
+    Enable Autologin as  Site Administrator
+    Goto Homepage
+
+    Add Files  @{valid_types}
+    Start Upload
+
+    # we just assume the file was successfully upload
+
+Test Upload Invalid Types
+    [Documentation]  Uploading audio files is not allowed by default
+
+    Enable Autologin as  Site Administrator
+    Goto Homepage
+
+    Add Files  @{invalid_types}
+
+    # FIXME: Firefox text enconding seems to be wrong
+    #        and displays "nÃ£o" instead of "não"
+    #        we need to check on the ff_profile directory
+    #        using this workaround meanwhile
+
+    # an error message "File type not allowed" must be shown
+    # Page Should Contain  Tipo de arquivo não permitido
+    Page Should Contain Element  css=.error
+
+*** Keywords ***
+
+Click Add Multiple Files
+    Open Add New Menu
+    Click Link  css=a#multiple-files
+    Wait Until Page Contains Element  @{upload_overlay_selector}
+
+Add Files
+    [Arguments]  @{files}
+
+    Click Add Multiple Files
+
+    # need to slow down Selenium here to avoid errors on images
+    ${speed} =  Set Selenium Speed  2 seconds
+
+    : FOR  ${file}  IN  @{files}
+    \  Choose File  css=input[type=file]  /tmp/${file}
+    \  Sleep  1s  Wait for file to load
+    \  Page Should Contain Element  css=input[type=text][value="${file}"]
+
+    Set Selenium Speed  ${speed}
+
+Start Upload
+    Click Button  css=.fileupload-buttonbar .start
+    Wait Until Page Does Not Contain Element  @{upload_overlay_selector}

--- a/src/brasil/gov/portal/tests/test_addons_settings.py
+++ b/src/brasil/gov/portal/tests/test_addons_settings.py
@@ -138,13 +138,12 @@ class AddonsSettingsTestCase(unittest.TestCase):
         self.assertEqual(self.nitf_settings.default_section, u'Notícias')
 
     def test_collective_upload_settings(self):
-        """ Images uploaded must be smaller than 1024x1024.
-        """
+        # images uploaded must be smaller than 1024x1024
         settings = self.registry.forInterface(IUploadSettings)
         self.assertEqual(settings.resize_max_width, 1024)
         self.assertEqual(settings.resize_max_height, 1024)
-        self.assertEqual(settings.upload_extensions,
-                         u'gif, jpeg, jpg, png, pdf, doc, txt, docx')
+        self.assertEqual(
+            settings.upload_extensions, u'gif|jpeg|jpg|png|pdf|doc|txt|docx')
 
     def test_sc_social_likes_settings(self):
         likes = self.portal['portal_properties'].sc_social_likes_properties


### PR DESCRIPTION
Format of this field was changed in https://github.com/collective/collective.upload/pull/89/commits/7c6f2f9827adea897cf0d970983cc5c77617e0ce without notice on the changelog.

fixes #392 