### PR TITLE
Adiciona [debug] para plone.app.robotframework.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         'test': [
             'brasil.gov.agenda',
             'collective.cover',
-            'plone.app.robotframework',
+            'plone.app.robotframework[debug]',
             'plone.app.testing [robot]',
             'plone.testing',
             'plonetheme.sunburst',


### PR DESCRIPTION
Esse é o padrão para pacotes gerados pelo bobtemplates.plone.

Ver https://github.com/plone/bobtemplates.plone/blob/b57e5c2fc2e74de4e527c8005a123eb8e0a80c5d/bobtemplates/plone/theme_package/setup.py.bob#L56

No momento desse commit, a versão que usamos de plone.app.robotframework dá suporte a isso.

https://github.com/plone/plone.app.robotframework/blob/1.1.1/setup.py#L78

Com a adição de [debug], é possível usar a keyword 'Debug' e ter acesso a um shell interativo.

Para mais detalhes, ver https://docs.plone.org/external/plone.app.robotframework/docs/source/debugging.html