### PR TITLE
Fix column widths on cover objects based on new layout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0a6 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Corrige a largura das columnas das capas de acordo ao novo layout.
+  [hvelarde]
+
 - Remove todos os portlets atribuídos à raíz do site.
   [hvelarde]
 

--- a/src/brasil/gov/portal/tests/test_upgrades.py
+++ b/src/brasil/gov/portal/tests/test_upgrades.py
@@ -210,10 +210,18 @@ class to10901TestCase(UpgradeBaseTestCase):
 
     def test_registered_steps(self):
         steps = len(self.setup.listUpgrades(self.profile_id)[0])
-        self.assertEqual(steps, 1)
+        self.assertEqual(steps, 2)
 
     def test_remove_root_portlets(self):
         title = u'Remove portlet assigments at portal root'
+        step = self._get_upgrade_step_by_title(title)
+        self.assertIsNotNone(step)
+
+        # execute upgrade step
+        self._do_upgrade(step)
+
+    def test_fix_column_widths(self):
+        title = u'Fix column widths on cover objects'
         step = self._get_upgrade_step_by_title(title)
         self.assertIsNotNone(step)
 

--- a/src/brasil/gov/portal/upgrades/v10901/__init__.py
+++ b/src/brasil/gov/portal/upgrades/v10901/__init__.py
@@ -23,3 +23,53 @@ def remove_portlet_assignments(obj):
 def remove_root_portlets(setup_tool):
     """Remove portlet assigments at portal root."""
     remove_portlet_assignments(api.portal.get())
+    logger.info('Portlet assignments removed from portal root')
+
+
+def get_valid_objects(**kw):
+    """Generate a list of objects associated with valid brains."""
+    catalog = api.portal.get_tool('portal_catalog')
+    results = catalog(**kw)
+    logger.info('Found {0} objects in the catalog'.format(len(results)))
+    for b in results:
+        try:
+            obj = b.getObject()
+        except (AttributeError, KeyError):
+            obj = None
+
+        if obj is None:  # warn on broken entries in the catalog
+            msg = 'Invalid object reference in the catalog: {0}'
+            logger.warn(msg.format(b.getPath()))
+            continue
+
+        yield obj
+
+
+def fix_cover_columns(setup_tool):
+    """Fix column widths on cover objects. Resulting width depends on
+    the number of columns in a row (width = 12 / columns).
+    """
+
+    import json
+
+    def fix_column_width(layout, columns=1):
+        """Traverse the layout tree and fix columns width."""
+        new_layout = []
+        for e in layout:
+            if 'column-size' in e:
+                e['column-size'] = 12 // columns
+            if e['type'] == 'row':
+                columns = len(e['children'])
+                e['children'] = fix_column_width(e['children'], columns)
+            new_layout.append(e)
+        return new_layout
+
+    for obj in get_valid_objects(portal_type='collective.cover.content'):
+        try:
+            layout = json.loads(obj.cover_layout)
+        except TypeError:
+            continue  # empty layout?
+        layout = fix_column_width(layout)
+        obj.cover_layout = json.dumps(layout)
+
+    logger.info('Column widths fixed on collective.cover objects')

--- a/src/brasil/gov/portal/upgrades/v10901/__init__.py
+++ b/src/brasil/gov/portal/upgrades/v10901/__init__.py
@@ -16,14 +16,15 @@ def remove_portlet_assignments(obj):
         manager = getUtility(IPortletManager, name=name)
         mapping = getMultiAdapter((obj, manager), IPortletAssignmentMapping)
         for i in mapping.keys():
-            logger.info('Removing portlet "{0}" from {1}'.format(i, obj))
+            logger.info('Portlet "{0}" removed'.format(i))
             del mapping[i]
 
 
 def remove_root_portlets(setup_tool):
     """Remove portlet assigments at portal root."""
+    logger.info('Removing portlet assigments at portal root')
     remove_portlet_assignments(api.portal.get())
-    logger.info('Portlet assignments removed from portal root')
+    logger.info('Done')
 
 
 def get_valid_objects(**kw):
@@ -64,6 +65,7 @@ def fix_cover_columns(setup_tool):
             new_layout.append(e)
         return new_layout
 
+    logger.info('Fixing column widths on collective.cover objects')
     for obj in get_valid_objects(portal_type='collective.cover.content'):
         try:
             layout = json.loads(obj.cover_layout)
@@ -72,4 +74,4 @@ def fix_cover_columns(setup_tool):
         layout = fix_column_width(layout)
         obj.cover_layout = json.dumps(layout)
 
-    logger.info('Column widths fixed on collective.cover objects')
+    logger.info('Done')

--- a/src/brasil/gov/portal/upgrades/v10901/configure.zcml
+++ b/src/brasil/gov/portal/upgrades/v10901/configure.zcml
@@ -12,6 +12,11 @@
         handler=".remove_root_portlets"
         />
 
+    <genericsetup:upgradeStep
+        title="Fix column widths on cover objects"
+        handler=".fix_cover_columns"
+        />
+
   </genericsetup:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
New layout has 12 columns instead of 16.