### PR TITLE
Do not install plone.restapi on upgrade step v10803

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.5.3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Remove instalação do plone.restapi no upgrade step v10803;
+  isso evita ``AttributeError`` na atualização à versão 1.5rc2 (fecha `#525 <https://github.com/plonegovbr/brasil.gov.portal/issues/525>`_).
+  [hvelarde]
+
 - Atualizado Plone à versão 4.3.18.
   [hvelarde]
 

--- a/src/brasil/gov/portal/profiles/default/metadata.xml
+++ b/src/brasil/gov/portal/profiles/default/metadata.xml
@@ -10,7 +10,6 @@
     <dependency>profile-brasil.gov.portlets:default</dependency>
     <dependency>profile-brasil.gov.vcge.at:default</dependency>
     <dependency>profile-brasil.gov.vcge.dx:default</dependency>
-    <dependency>profile-plone.restapi:default</dependency>
     <dependency>profile-Products.Doormat:default</dependency>
     <dependency>profile-Products.PloneFormGen:default</dependency>
     <dependency>profile-Products.RedirectionTool:default</dependency>

--- a/src/brasil/gov/portal/tests/test_setup.py
+++ b/src/brasil/gov/portal/tests/test_setup.py
@@ -46,7 +46,6 @@ DEPENDENCIES = [
     'collective.upload',
     'plone.app.contenttypes',
     'plone.app.theming',
-    'plone.restapi',
     'Products.Doormat',
     'Products.PloneFormGen',
     'Products.RedirectionTool',

--- a/src/brasil/gov/portal/tests/test_upgrades.py
+++ b/src/brasil/gov/portal/tests/test_upgrades.py
@@ -41,7 +41,7 @@ class To10803TestCase(UpgradeBaseTestCase):
 
     def test_registered_steps(self):
         steps = len(self.setup.listUpgrades(self.profile_id)[0])
-        self.assertEqual(steps, 5)
+        self.assertEqual(steps, 4)
 
     def test_install_redirection_tool(self):
         title = u'Install Products.RedirectionTool'
@@ -50,22 +50,6 @@ class To10803TestCase(UpgradeBaseTestCase):
 
         # simulate (partially) state on previous version
         addon = 'RedirectionTool'
-        qi = api.portal.get_tool('portal_quickinstaller')
-        with api.env.adopt_roles(['Manager']):
-            qi.uninstallProducts([addon])
-        self.assertFalse(qi.isProductInstalled(addon))
-
-        # execute upgrade step and verify changes were applied
-        self._do_upgrade(step)
-        self.assertTrue(qi.isProductInstalled(addon))
-
-    def test_install_restapi(self):
-        title = u'Install plone.restapi'
-        step = self._get_upgrade_step_by_title(title)
-        self.assertIsNotNone(step)
-
-        # simulate state on previous version
-        addon = 'plone.restapi'
         qi = api.portal.get_tool('portal_quickinstaller')
         with api.env.adopt_roles(['Manager']):
             qi.uninstallProducts([addon])

--- a/src/brasil/gov/portal/upgrades/v10803/__init__.py
+++ b/src/brasil/gov/portal/upgrades/v10803/__init__.py
@@ -13,15 +13,6 @@ def install_redirection_tool(setup_tool):
         logger.info('Products.RedirectionTool was installed')
 
 
-def install_restapi(setup_tool):
-    """Install plone.restapi."""
-    addon = 'plone.restapi'
-    qi = api.portal.get_tool('portal_quickinstaller')
-    if not qi.isProductInstalled(addon):
-        qi.installProduct(addon)
-        logger.info(addon + ' was installed')
-
-
 def uninstall_widgets(setup_tool):
     """Uninstall collective.z3cform.widgets."""
     from collective.z3cform.widgets.interfaces import ILayer

--- a/src/brasil/gov/portal/upgrades/v10803/configure.zcml
+++ b/src/brasil/gov/portal/upgrades/v10803/configure.zcml
@@ -24,12 +24,6 @@
         />
 
     <genericsetup:upgradeStep
-        title="Install plone.restapi"
-        description=""
-        handler=".install_restapi"
-        />
-
-    <genericsetup:upgradeStep
         title="Uninstall collective.z3cform.widgets"
         description=""
         handler=".uninstall_widgets"


### PR DESCRIPTION
closes #525 
refs. https://github.com/plone/plone.restapi/issues/465
refs. https://github.com/plone/plone.rest/issues/73