### PR TITLE
Adicionado suporte a rede LinkedIn.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Adicionado suporte a rede LinkedIn.
+  [talau]
 
 
 2.1.1 (2018-12-08)

--- a/src/brasil/gov/portal/config.py
+++ b/src/brasil/gov/portal/config.py
@@ -39,6 +39,9 @@ REDES = [
     {'id': 'tumblr',
      'title': 'Thumblr',
      'url': 'https://%s.tumblr.com'},
+    {'id': 'linkedin',
+     'title': 'LinkedIn',
+     'url': 'https://www.linkedin.com/%s'},
 ]
 
 # http://www.tinymce.com/wiki.php/Configuration:formats


### PR DESCRIPTION
Foi adicionado o suporte a rede LinkedIn. Para uso completo da rede social no plone foi feito outro patch no projeto brasil.gov.temas.