### PR TITLE
MPEG e OGG Audio File podem ser editados pela folder_contents.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.1.2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Permite edição do tipo "MPEG Audio File" e "OGG Audio File" através da aba "Conteúdo". (atende parcialmente `#587 <https://github.com/plonegovbr/brasil.gov.portal/issues/587>`_).
+  [idgserpro]
 - Permite edição do tipo Infográfico através da aba "Conteúdo". (atende parcialmente `#578 <https://github.com/plonegovbr/brasil.gov.portal/issues/578>`_).
   [idgserpro]
 

--- a/src/brasil/gov/portal/profiles/default/propertiestool.xml
+++ b/src/brasil/gov/portal/profiles/default/propertiestool.xml
@@ -73,6 +73,8 @@
     </property>
     <property name="typesUseViewActionInListings" type="lines" purge="false">
       <element value="Infographic"/>
+      <element value="MPEG Audio File"/>
+      <element value="OGG Audio File"/>
     </property>
     <property name="icon_visibility" type="string">authenticated</property>
   </object>

--- a/src/brasil/gov/portal/tests/test_contentcentral_view.py
+++ b/src/brasil/gov/portal/tests/test_contentcentral_view.py
@@ -48,15 +48,26 @@ class ContentCentralViewTestCase(unittest.TestCase):
 
     def test_media(self):
         from collections import OrderedDict
-        self.assertEqual(self.view.media(), OrderedDict())
+        # Esse teste tem resultados diferentes se for executado manualmente ou
+        # em conjunto com os demais testes com o uso de bin/test --all.
+        # Isso ocorre porque os testes em test_audio_content_type.py usam
+        # transaction.commit(), portanto, eles já existem quando esse teste é
+        # executado quando se usa o bin/test --all.
+        # ('test-folder-MPEG', 'test-folder-OGG')
+        if 'test-folder-MPEG' in self.portal.objectIds():
+            self.assertEqual(self.view.media(), OrderedDict([('Audio', u'Audio')]))
+        else:
+            self.assertEqual(self.view.media(), OrderedDict())
 
         api.content.create(self.folder, 'Image', 'foo')
         api.content.create(self.folder, 'File', 'bar')
-        self.assertEqual(
-            self.view.media(), OrderedDict([('Image', u'Image')]))
-        api.content.create(self.folder, 'Audio', 'baz')
-        self.assertEqual(
-            self.view.media(),
-            OrderedDict([('Image', u'Image'), ('Audio', u'Audio')]))
+
+        if 'test-folder-MPEG' in self.portal.objectIds():
+            self.assertEqual(
+                self.view.media(),
+                OrderedDict([('Image', u'Image'), ('Audio', u'Audio')]))
+        else:
+            self.assertEqual(
+                self.view.media(), OrderedDict([('Image', u'Image')]))
 
     # TODO: add more tests

--- a/src/brasil/gov/portal/tests/utils.py
+++ b/src/brasil/gov/portal/tests/utils.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+
+import transaction
+
+
+def login_browser(browser, portal):
+    """Autentica usuário de teste no browser"""
+    setRoles(portal, TEST_USER_ID, ['Site Administrator'])
+    browser.handleErrors = False
+    basic_auth = 'Basic {0}'.format(
+        '{0}:{1}'.format(TEST_USER_NAME, TEST_USER_PASSWORD),
+    )
+    browser.addHeader('Authorization', basic_auth)
+    transaction.commit()

--- a/src/brasil/gov/portal/upgrades/v10907/configure.zcml
+++ b/src/brasil/gov/portal/upgrades/v10907/configure.zcml
@@ -16,7 +16,7 @@
       profile="brasil.gov.portal:default">
 
     <genericsetup:upgradeDepends
-        title="Torna possivel editar um infografico em folder_contents."
+        title="Torna possivel editar um infografico, MPEG Audio File e OGG Audio File em folder_contents."
         import_profile="brasil.gov.portal.upgrades.v10907:default"
         />
 

--- a/src/brasil/gov/portal/upgrades/v10907/profile/propertiestool.xml
+++ b/src/brasil/gov/portal/upgrades/v10907/profile/propertiestool.xml
@@ -3,6 +3,8 @@
   <object name="site_properties" meta_type="Plone Property Sheet">
     <property name="typesUseViewActionInListings" type="lines" purge="false">
       <element value="Infographic"/>
+      <element value="MPEG Audio File"/>
+      <element value="OGG Audio File"/>
     </property>
   </object>
 </object>


### PR DESCRIPTION
Corrige parcialmente https://github.com/plonegovbr/brasil.gov.portal/issues/587 para a branch 2.x.