### PR TITLE
Corrige "Can't open /etc/init.d/xvfb" no travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+services:
+  - xvfb
 language: python
 python: 2.7
 sudo: false
@@ -20,9 +22,6 @@ install:
 - python bootstrap.py
 - bin/buildout annotate
 - bin/buildout
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 script:
 - bin/code-analysis
 - bin/test


### PR DESCRIPTION
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Com isso, o formato de execução do xvfb foi alterado:

https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

services:
  - xvfb
